### PR TITLE
fix on feature by path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.1.4] - Not released yet
 ### Added
 - `getModuleVersions` - thanks @efouret !
+- `updateInstanceProperties` private method - thanks @achoimet !
+- `updateModuleProperties` private method - thanks @achoimet !
+- `updatePathSpecificProperties` private method - thanks @achoimet !
 
 ### Fixed
 - `getAppInfo` method - thanks @efouret !
+
+### Changed
+- `updateProperties` now the method is easier to understand, she calls 3 others private methods - thanks @achoimet !
 
 
 ## [1.1.3] - 2017-10-11
@@ -33,7 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.1.1] - 2017-09-14
 ### Added
 - `deleteInstance` now supports a wildcard '*' value for its `instance` parameter
-
+ 
 
 ## [1.1.0] - 2017-08-16
 Publication on Github

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   redis: 
     image: "redis" 
   hesperides: 
-    image: "hesperides/hesperides"
+    image: "hesperides/hesperides:demo-chaos"
     ports: 
       - "8080:8080"
     depends_on:

--- a/test/HesperidesIntegrationSpec.groovy
+++ b/test/HesperidesIntegrationSpec.groovy
@@ -161,7 +161,7 @@ class HesperidesIntegrationSpec extends Specification implements Helper {
                     "LCM_vha_test_instance_property": "hello World !"
                   },
                   "path:#${logicGroupNameTwo}#${subLogicGroup}#${secondModuleName}": {
-                    "LCM_vha_test_instance_property": "hello World on custom path!"
+                    "propriete_commune_secondmodule": "Canon Garrick"
                   },
                   "${secondModuleName}": {
                      "propriete_commune_secondmodule": "Kamehameha"
@@ -181,17 +181,19 @@ class HesperidesIntegrationSpec extends Specification implements Helper {
             jsonFile.delete()
 
             def modulePropertiesPath = "#${logicGroupName}#${subLogicGroup}#${moduleName}#${moduleVersion}#WORKINGCOPY"
-            def moduleTwoPropertiesPath = "#${logicGroupNameTwo}#${subLogicGroup}#${secondModuleName}#${moduleVersion}#WORKINGCOPY"
+            def moduleTwoPropertiesPath = "#${logicGroupName}#${subLogicGroup}#${secondModuleName}#${moduleVersion}#WORKINGCOPY"
+            def moduleTwoPropertiesPathTwo = "#${logicGroupNameTwo}#${subLogicGroup}#${secondModuleName}#${moduleVersion}#WORKINGCOPY"
             def platformProps = hesperides.getModulePropertiesForPlatform(app: applicationName, platform: platformName, modulePropertiesPath: modulePropertiesPath)
             def platformPropsModuleTwo = hesperides.getModulePropertiesForPlatform(app: applicationName, platform: platformName, modulePropertiesPath: moduleTwoPropertiesPath)
+            def platformPropsModuleTwoOtherPath = hesperides.getModulePropertiesForPlatform(app: applicationName, platform: platformName, modulePropertiesPath: moduleTwoPropertiesPathTwo)
             def globalProps = hesperides.getModulePropertiesForPlatform(app: applicationName, platform: platformName, modulePropertiesPath: '#')
             def instanceProps = hesperides.getInstanceProperties(app: applicationName, platform: platformName, moduleName: moduleName, instance: instanceName)
-            def instancePropsModuleTwo = hesperides.getInstanceProperties(app: applicationName, platform: platformName, moduleName: secondModuleName, instance: instanceNameThree, path: "#${logicGroupNameTwo}#${subLogicGroup}")
+            log("platform pppties:"+platformPropsModuleTwo)
 
         then:
             platformProps['key_value_properties'].find { it.name == 'LCM_vha_test_property' }
             platformProps['key_value_properties'].find { it.name == 'LCM_vha_test_property' }['value'] == '42'
-            platformPropsModuleTwo['key_value_properties'].find{ it.name == 'propriete_commune_secondmodule'}['value'] == 'Kamehameha'
+            platformPropsModuleTwo['key_value_properties'].find { it.name == 'propriete_commune_secondmodule'}['value'] == 'Kamehameha'
             platformProps['key_value_properties'].find {
                 it.name == 'LCM_vha_test_builtin_property'
             }['value'] == '{{hesperides.platform.name}}'
@@ -213,7 +215,7 @@ class HesperidesIntegrationSpec extends Specification implements Helper {
                 it.name == 'LCM_vha_test_global_property'
             }['value'] == 'Over 9000 !'
             instanceProps['key_values'].find { it.name == 'LCM_vha_test_instance_property' }['value'] == 'hello World !'
-            instancePropsModuleTwo['key_values'].find { it.name == 'LCM_vha_test_instance_property' }['value'] == 'hello World on custom path!'
+            platformPropsModuleTwoOtherPath['key_value_properties'].find { it.name == 'propriete_commune_secondmodule'}['value'] == 'Canon Garrick'
     }
 
     def "Can upgrade platform version"() {

--- a/vars/hesperides.txt
+++ b/vars/hesperides.txt
@@ -132,11 +132,11 @@
             }
           },
           "another-module#INSTANCE_NAME": {},
-          "path:#logicGroup#another-third-module": {
-            "polymorphistic_property": "a value"
+          "another-third-module": {
+            "polymorphistic_property": "a default value on the platform"
           },
           "path:#anotherLogicGroup#another-third-module": {
-            "polymorphistic_property": "another value"
+            "polymorphistic_property": "an overriden value for a specific path"
           },
           "GLOBAL": {}
         }


### PR DESCRIPTION
the feature was not correct.

Here the fix : 
- Add properties for modules (normal way) but with an exclusion of all properties added with path:, without the fix, the properties with :path are replaced by the original value...

Use case of this fix : we want one property to have a same value everywhere but not on a specific path

{
mymodule:{
myprop: "toto"
},
path:#GROUP#SUBGROUP#mymodule:{
myprop: "toto"
}
}

The related test has been fix.