### PR TITLE
[JFL] - Correction nom fonction car erreur lors de l'appel

### DIFF
--- a/vars/hesperides.groovy
+++ b/vars/hesperides.groovy
@@ -242,7 +242,7 @@ def getDiffPropertiesAsString(Map args) {
     new Hesperides(apiRootUrl: args.apiRootUrl,
             auth: args.auth,
             httpRequester: new JenkinsHTTRequester(this.steps),
-            steps: this.steps).getDiffPropDisplay(args)
+            steps: this.steps).getDiffPropertiesAsString(args)
 }
 
 /******************************************************************************


### PR DESCRIPTION
Correction d'une petite coquille qui est restée suite au changement de nom de la fonction afin que celle-ci soit plus"parlante". 